### PR TITLE
Scope DB transaction inside Kafka transaction

### DIFF
--- a/kafka-orm-transactions/src/main/java/acme/NewAuthorConsumer.java
+++ b/kafka-orm-transactions/src/main/java/acme/NewAuthorConsumer.java
@@ -7,7 +7,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
-import org.eclipse.microprofile.reactive.messaging.Message;
 
 /**
  * Approach 1: Using MutinyEmitter
@@ -63,6 +62,9 @@ public class NewAuthorConsumer {
         return kafkaTx.withTransaction(emitter -> {
             persistAuthor(message);
             emitter.send(message + "-book1");
+            if (message.equals("Jack")) {
+                emitter.markForAbort();
+            }
             return Uni.createFrom().voidItem();
         });
     }
@@ -70,6 +72,6 @@ public class NewAuthorConsumer {
     private void persistAuthor(String name) {
         Author author = new Author();
         author.name = name;
-        author.persist();
+        author.persistAndFlush();
     }
 }

--- a/kafka-orm-transactions/src/main/java/acme/NewBookConsumer.java
+++ b/kafka-orm-transactions/src/main/java/acme/NewBookConsumer.java
@@ -3,11 +3,12 @@ package acme;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
+import java.util.concurrent.CompletionStage;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
 
 @ApplicationScoped
 public class NewBookConsumer {
-
     @Transactional
     @Incoming("new-book-in")
     void consume(String title) {
@@ -16,4 +17,19 @@ public class NewBookConsumer {
         book.title = title;
         book.persist();
     }
+
+//
+//    @Transactional
+//    @Incoming("new-book-in")
+//    CompletionStage<Void> consume(Message<String> msg) {
+//        String title = msg.getPayload();
+//        Log.infov("Received new message in books topic with title `{0}`", title);
+//        if (title.equals("Jack-book1")) {
+//            return msg.nack(new IllegalStateException("Hello World"));
+//        }
+//        Book book = new Book();
+//        book.title = title;
+//        book.persist();
+//        return msg.ack();
+//    }
 }

--- a/kafka-orm-transactions/src/main/java/acme/Resource.java
+++ b/kafka-orm-transactions/src/main/java/acme/Resource.java
@@ -1,5 +1,6 @@
 package acme;
 
+import io.quarkus.logging.Log;
 import java.util.List;
 import io.smallrye.reactive.messaging.MutinyEmitter;
 
@@ -20,6 +21,7 @@ public class Resource {
     @GET
     @Path("/authors")
     public List<Author> authors() {
+        Log.info("Fetch authors");
         return Author.listAll();
     }
 
@@ -27,6 +29,7 @@ public class Resource {
     @GET
     @Path("/books")
     public List<Book> books() {
+        Log.info("Fetch books");
         return Book.listAll();
     }
 
@@ -34,6 +37,7 @@ public class Resource {
     @POST
     @Path("/authors/{name}")
     public void submitAuthor(@RestPath String name) {
+        Log.infov("Write author {0}", name);
         newAuthor.sendAndAwait(name);
     }
 }

--- a/kafka-orm-transactions/test.sh
+++ b/kafka-orm-transactions/test.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# https://github.com/olivergondza/bash-strict-mode
+set -eEuo pipefail
+trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
+trap 'kill $(jobs -p) 2>/dev/null' SIGINT SIGTERM EXIT
+
+LOG=$(mktemp /tmp/maven-XXXXX.log)
+
+function txTest() {
+    name="$1"
+    echo
+    echo "Testing $name"
+    curl -X POST "http://localhost:8080/api/authors/${name}"
+    sleep 5
+    books=$(curl -s http://localhost:8080/api/books)
+    echo "Books: $books"
+
+    if [ "$books" == "$2" ]; then
+        echo "Success - $name book record"
+    else
+        echo "Failure - $name book record"
+        exit 1
+    fi
+
+    authors=$(curl -s http://localhost:8080/api/authors)
+    echo "Authors: $authors"
+    if [ "$authors" == "$3" ]; then
+      echo "Success - $name author record"
+    else
+        echo "Failure - $name author record"
+        exit 1
+    fi
+
+}
+
+mvn quarkus:dev > $LOG &
+
+while ! grep -q -m1 'Live Coding activated' < $LOG; do
+    sleep 2
+done
+
+tmux splitw tail -f $LOG
+
+case "$1" in
+  al)
+    txTest "Al" '[{"id":1,"title":"Al-book1"}]' '[{"name":"Al"},{"name":"Jose"}]'
+    ;;
+  jose)
+    txTest "Jose" '[]' '[{"name":"Jose"}]'
+    ;;
+  jack)
+    txTest "Jack" '[]' '[{"name":"Jose"}]'
+    ;;
+  all)
+    txTest "Al" '[{"id":1,"title":"Al-book1"}]' '[{"name":"Al"},{"name":"Jose"}]'
+    txTest "Jose" '[{"id":1,"title":"Al-book1"}]' '[{"name":"Al"},{"name":"Jose"}]'
+    txTest "Jack" '[{"id":1,"title":"Al-book1"}]' '[{"name":"Al"},{"name":"Jose"}]'
+    ;;
+  *)
+    echo "Use 'al', 'jose', 'jack', or 'all'"
+    ;;
+esac


### PR DESCRIPTION
Just run the `test.sh` script.  Comment out the line with the tmux command if you aren't using tmux.

I had to add the `Blocking` annotation to avoid a "Cannot start a JTA transaction from the IO thread" error.

I am not enough of an expert to say whether adding that `Blocking` annotation is going to be an issue.  The [docs](https://quarkus.io/blog/resteasy-reactive-smart-dispatch/) indicate that having the `Transactional` annotation on `consume` (as in previous versions) will configure the dispatching strategy to use a worker thread. as I understand it adding `@Blocking` is just explicitly configuring it to a worker thread since removing `@Transactional` would otherwise result in assignment to the IO thread.

I also had the idea of maybe handling the DB transaction manually inside the
`withTransaction` closure.
